### PR TITLE
Added 2 other, required app to whitelist

### DIFF
--- a/api/v3/canonical/defaults/filters.txt
+++ b/api/v3/canonical/defaults/filters.txt
@@ -267,3 +267,20 @@ https://blokada.org
 app
 com.android.phone
 
+
+150
+b_app_telephony
+whitelist
+active
+https://blokada.org
+app
+com.android.providers.telephony
+
+
+160
+b_app_hwsysmanager
+whitelist
+inactive
+https://blokada.org
+app
+com.huawei.systemmanager

--- a/api/v3/canonical/defaults/filters.txt
+++ b/api/v3/canonical/defaults/filters.txt
@@ -284,3 +284,5 @@ inactive
 https://blokada.org
 app
 com.huawei.systemmanager
+
+


### PR DESCRIPTION
Added com.android.providers.telephony and com.huawei.systemmanager (inactive, by default) to the default whitelist.