### PR TITLE
Updating Steven Black's social host's link

### DIFF
--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -112,8 +112,7 @@ blacklist
 inactive
 https://github.com/StevenBlack/hosts
 link
-https://raw.githubusercontent.com/StevenBlack/hosts/master/extensions/social/hosts
-
+https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/social/hosts
 
 80
 b_mining


### PR DESCRIPTION
The link of the social list changes, here I update to the new one.