### PR TITLE
Updating Help's link

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
                         <a class="page-scroll" href="#you">Get involved</a>
                     </li>
                     <li>
-                        <a href="https://support.blokada.org" href="#help">Help</a>
+                        <a href="https://support.blokada.org">Help</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="https://block.blokada.org">News</a>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
                         <a class="page-scroll" href="#you">Get involved</a>
                     </li>
                     <li>
-                        <a href="docs/help.html" href="#you">Help</a>
+                        <a href="https://support.blokada.org" href="#help">Help</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="https://block.blokada.org">News</a>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
                         <a href="https://support.blokada.org">Help</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="https://block.blokada.org">News</a>
+                        <a href="https://block.blokada.org">News</a>
 		    </li>
                 </ul>
             </div>


### PR DESCRIPTION
Help's link is set to point to the new site and removed some useless things