### PR TITLE
Removing HpHsts, adding Phishing Army

### DIFF
--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -88,6 +88,15 @@ link
 https://raw.githubusercontent.com/jerryn70/GoodbyeAds/master/Extension/GoodbyeAds-YouTube-AdBlock.txt
 
 
+25
+b_phishingarmy
+blacklist
+inactive
+https://phishing.army/
+link
+https://phishing.army/download/phishing_army_blocklist_extended.txt
+
+
 30
 b_mvps
 blacklist

--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -88,15 +88,6 @@ link
 https://raw.githubusercontent.com/jerryn70/GoodbyeAds/master/Extension/GoodbyeAds-YouTube-AdBlock.txt
 
 
-25
-b_hphosts
-blacklist
-inactive
-https://hosts-file.net/?s=Download
-link
-https://hosts-file.net/ad_servers.txt
-
-
 30
 b_mvps
 blacklist

--- a/api/v4/canonical/strings/filters.properties
+++ b/api/v4/canonical/strings/filters.properties
@@ -38,3 +38,5 @@ b_samsung_name = Samsung blocker by Jerryn70
 b_samsung_comment = Extension list specifically for Samsung phones, to avoid sharing your data.
 b_youtube_name = YouTube Ad Blocker by Jerryn70
 b_youtube_comment = The list that aims to block YouTube ads. Please note we can not ensure nor promise that all of them will be filtered.
+b_phishingarmy_name = Phishing Army Blocklist
+b_phishingarmy_comment = Do you also get a lot of e-mails saying you need to update your bank account details or your password? Phishing Army fights against those fraudulent domains that try to obtain sensitive information like credit card details, username, password, etc by misleading the user.

--- a/api/v4/canonical/strings/filters.properties
+++ b/api/v4/canonical/strings/filters.properties
@@ -1,7 +1,5 @@
 b_unified_name = StevenBlack Unified
 b_unified_comment = A great choice that strives to keep balance between blocking effectiveness, battery impact and false positives. Try this list if other ones are blocking too much.
-b_hphosts_name = HpHosts
-b_hphosts_comment = A rigorous configuration which will block more ads, but may occasionally mistakenly block desired content. This is a good choice if the default choice is not effective enough for you.
 b_mvps_name = MVPS
 b_mvps_comment = A lenient, less resource-intensive configuration which will omit more ads than the default one, but may improve battery life and device performance. This is a great choice if you are experiencing any issues with your device or apps.
 b_adaway_name = AdAway


### PR DESCRIPTION
It seems HpHosts is acquired by Malwarebytes, the hostfile's link simply redirects to malwarebytes.com

Issues: #[657](https://github.com/blokadaorg/blokada/issues/657) and #[683](https://github.com/blokadaorg/blokada/issues/683)