### PR TITLE
Add Conversations and jitsi-meet to the whitelist

### DIFF
--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -402,6 +402,7 @@ https://blokada.org
 app
 com.xiaomi.discover
 
+
 178
 b_app_conversations
 whitelist
@@ -410,6 +411,7 @@ https://blokada.org
 app
 eu.siacs.conversations
 
+
 179
 b_app_jitsimeet
 whitelist
@@ -417,4 +419,5 @@ active
 https://blokada.org
 app
 org.jitsi.meet
+
 

--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -409,3 +409,12 @@ active
 https://blokada.org
 app
 eu.siacs.conversations
+
+179
+b_app_jitsimeet
+whitelist
+active
+https://blokada.org
+app
+org.jitsi.meet
+

--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -402,4 +402,10 @@ https://blokada.org
 app
 com.xiaomi.discover
 
-
+178
+b_app_conversations
+whitelist
+active
+https://blokada.org
+app
+eu.siacs.conversations


### PR DESCRIPTION
In the current beta the XMPP client conversations supports VoIP.
A/V calls fails as long as Conversations is not whitelisted in Blokada.

Jitsi-meet is also unable to establish A/V conferences until it is 
whitelisted in Blokada.

Both apps are open source, available in fdroid and can be used with own servers so I consider them trustworthy enough to add them to the default whitelist.