### PR TITLE
Add conversations and jitsi-meet to whitelist

### DIFF
--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -409,3 +409,12 @@ active
 https://blokada.org
 app
 eu.siacs.conversations
+
+179
+b_app_jitsimeet
+whitelist
+active
+https://blokada.org
+app
+org.jitsi.meet
+

--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -402,4 +402,10 @@ https://blokada.org
 app
 com.xiaomi.discover
 
-
+178
+b_app_conversations
+whitelist
+active
+https://blokada.org
+app
+eu.siacs.conversations


### PR DESCRIPTION
Both apps A/V functionality won't work without being on Blokadas blacklist. 