### PR TITLE
Removing MobileAdTracker

### DIFF
--- a/api/v4/canonical/defaults/filters.txt
+++ b/api/v4/canonical/defaults/filters.txt
@@ -160,15 +160,6 @@ link
 https://raw.githubusercontent.com/jerryn70/GoodbyeAds/master/Extension/GoodbyeAds-Xiaomi-Extension.txt
 
 
-65
-b_mat
-blacklist
-inactive
-https://github.com/jawz101/MobileAdTrackers
-link
-https://raw.githubusercontent.com/jawz101/MobileAdTrackers/master/hosts
-
-
 20
 b_app_vending
 whitelist


### PR DESCRIPTION
The list isn't maintained since 14th of January, 2020