### PR TITLE
Clarifying supported devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,7 @@
                     <p class="justin"><b>New: Blokada 5 is now available for Android and iOS</b>! We are excited about this release, and hope you will like it. Remember, it does not have all the features of Blokada v4, yet. <a href="https://go.blokada.org/community_5beta">Read more</a></p>
                     <p><a href="https://go.blokada.org/apk5" class="btn btn-default btn-lg"><i class="fas fa-download"></i> Get Blokada 5 (Android)</a></p>
                     <p><a href="https://go.blokada.org/appstore"><img alt="Download Blokada 5 on the AppStore" src="img/appstore.svg" width="200" /></a></p>
+		    <p>Please note Blokada 5 for Android is optimised for phones and tablets running Android 7 and newer versions. In case you have a different device, please use Blokada 4.</p>
                     <p>&nbsp;</p>
 
                     <h2>Download Blokada 4 for Android</h2>


### PR DESCRIPTION
Blokada v5 doesn't support TVs and TV devices, and devices running Android 6 or older version.